### PR TITLE
Efficiency changes

### DIFF
--- a/pyHype/blocks/QuadBlock.py
+++ b/pyHype/blocks/QuadBlock.py
@@ -933,8 +933,8 @@ class QuadBlock:
     def get_interface_values(self) -> [np.ndarray]:
 
         if self.inputs.interface_interpolation == 'arithmetic_average':
-            interfaceEW, interfaceNS = self.get_interface_values_arithmetic()
-            return interfaceEW, interfaceNS
+            interfaceE, interfaceW, interfaceN, interfaceS = self.get_interface_values_arithmetic()
+            return interfaceE, interfaceW, interfaceN, interfaceS
         else:
             raise ValueError('Interface Interpolation method is not defined.')
 
@@ -954,7 +954,7 @@ class QuadBlock:
         interfaceEW = 0.5 * (catx[:, 1:, :] + catx[:, :-1, :])
         interfaceNS = 0.5 * (caty[1:, :, :] + caty[:-1, :, :])
 
-        return interfaceEW, interfaceNS
+        return interfaceEW[:, 1:, :], interfaceEW[:, :-1, :], interfaceNS[1:, :, :], interfaceNS[:-1, :, :]
 
     # ------------------------------------------------------------------------------------------------------------------
     # Time stepping methods

--- a/pyHype/solvers/Euler2D.py
+++ b/pyHype/solvers/Euler2D.py
@@ -130,19 +130,18 @@ class Euler2D(Solver):
         print('Date and time: ', datetime.today())
 
         if self.inputs.profile:
-            print('\t>>> Enabling Profiler')
+            print('\n>>> Enabling Profiler')
             profiler = cProfile.Profile()
             profiler.enable()
         else:
             profiler = None
 
         while self.t < self.t_final:
-            """if self.numTimeStep % 50 == 0:
-                print()
-                print('Simulation time: ' + str(self.t / self.inputs.a_inf))
+            if self.numTimeStep % 50 == 0:
+                print('\nSimulation time: ' + str(self.t / self.inputs.a_inf))
                 print('Timestep number: ' + str(self.numTimeStep))
             else:
-                print('.', end='')"""
+                print('.', end='')
 
             # Get time step
             self.dt = self.get_dt()


### PR DESCRIPTION
1) get_interface_values() of QuadBlock returns the interface values at each interface individually, and not at EW and NS
2) Limiter slope calculation is not split into two np.where calls, which is a bit inefficient. Combine the two into one JIT'ed function