### PR TITLE
Removed conservative upwinding from Roe flux

### DIFF
--- a/pyHype/flux/HLLE.py
+++ b/pyHype/flux/HLLE.py
@@ -23,9 +23,7 @@ from pyHype.states.states import RoePrimitiveState, ConservativeState, Primitive
 class FluxHLLE(FluxFunction):
     def compute_flux(self,
                      WL: PrimitiveState,
-                     WR: PrimitiveState,
-                     UL: ConservativeState = None,
-                     UR: ConservativeState = None,
+                     WR: PrimitiveState
                      ) -> np.ndarray:
 
         # Get Roe state
@@ -40,6 +38,9 @@ class FluxHLLE(FluxFunction):
 
         L_plus = np.maximum.reduce((R_m, Lm))[:, :, None]
         L_minus = np.minimum.reduce((L_p, Lp))[:, :, None]
+
+        UR = WR.to_conservative_state()
+        UL = WL.to_conservative_state()
 
         FluxR = WR.F(U=UR)
         FluxL = WL.F(U=UL)

--- a/pyHype/flux/HLLL.py
+++ b/pyHype/flux/HLLL.py
@@ -24,9 +24,7 @@ from pyHype.states.states import PrimitiveState, RoePrimitiveState, Conservative
 class FluxHLLL(FluxFunction):
     def compute_flux(self,
                      WL: PrimitiveState,
-                     WR: PrimitiveState,
-                     UL: [ConservativeState, np.ndarray] = None,
-                     UR: [ConservativeState, np.ndarray] = None,
+                     WR: PrimitiveState
                      ) -> np.ndarray:
 
         # Get Roe state
@@ -41,6 +39,9 @@ class FluxHLLL(FluxFunction):
 
         L_plus = np.maximum.reduce((R_m, Lm))[:, :, None]
         L_minus = np.minimum.reduce((L_p, Lp))[:, :, None]
+
+        UR = WR.to_conservative_state()
+        UL = WL.to_conservative_state()
 
         # Left and right fluxes
         FluxR = WR.F(U=UR)

--- a/pyHype/flux/base.py
+++ b/pyHype/flux/base.py
@@ -33,29 +33,14 @@ class FluxFunction:
         self.n = inputs.n
 
     def __call__(self,
-                 stateL: State,
-                 stateR: State,
+                 WL: PrimitiveState,
+                 WR: PrimitiveState,
                  *args, **kwargs):
-
-        if isinstance(stateL, PrimitiveState):
-            _WL = stateL
-            _UL = _WL.to_conservative_state()
-        elif isinstance(stateL, ConservativeState):
-            _UL = stateL
-            _WL = _UL.to_primitive_state()
-        else:
-            raise TypeError('FluxFunction.__call__() Error, unknown state type.')
-
-        if isinstance(stateR, PrimitiveState):
-            _WR = stateR
-            _UR = _WR.to_conservative_state()
-        elif isinstance(stateR, ConservativeState):
-            _UR = stateR
-            _WR = _UR.to_primitive_state()
-        else:
-            raise TypeError('FluxFunction.__call__() Error, unknown state type.')
-
-        return self.compute_flux(_WL, _WR, _UL, _UR)
+        if not isinstance(WL, PrimitiveState):
+            raise TypeError('FluxFunction.__call__() Error, WL must be a PrimitiveState.')
+        if not isinstance(WR, PrimitiveState):
+            raise TypeError('FluxFunction.__call__() Error, WR must be a PrimitiveState.')
+        return self.compute_flux(WL, WR)
 
     @staticmethod
     def wavespeeds_x(W: PrimitiveState) -> [np.ndarray]:
@@ -171,8 +156,6 @@ class FluxFunction:
     @abstractmethod
     def compute_flux(self,
                      WL: PrimitiveState,
-                     WR: PrimitiveState,
-                     UL: [ConservativeState, np.ndarray],
-                     UR: [ConservativeState, np.ndarray],
+                     WR: PrimitiveState
                      ) -> np.ndarray:
         raise NotImplementedError


### PR DESCRIPTION
Primitive upwinding is equivalent but more efficient.