### PR TITLE
DEV: Remove 'upwind_mode' as required input

### DIFF
--- a/pyHype/solvers/base.py
+++ b/pyHype/solvers/base.py
@@ -41,7 +41,6 @@ class ProblemInput:
     __REQUIRED__ = ['problem_type',
                     'interface_interpolation',
                     'reconstruction_type',
-                    'upwind_mode',
                     'write_solution',
                     'write_solution_mode',
                     'write_solution_name',


### PR DESCRIPTION
There is no longer the option to select an upwinding mode for the Roe solver. Only primitive upwinding is available because it is identical in its result to the conservative upwinding, but more efficient computationally.