### PR TITLE
BUG FIX: Fix setting of initial conditions

### DIFF
--- a/pyHype/solvers/initial_conditions/initial_conditions.py
+++ b/pyHype/solvers/initial_conditions/initial_conditions.py
@@ -190,7 +190,7 @@ def subsonic_flood(blocks, **kwargs):
 
     # Fill state vector in each block
     for block in blocks:
-        block.state.U = Q
+        block.state.U[:, :, :] = Q
         block.state.non_dim()
 
 def supersonic_rest(blocks, **kwargs):
@@ -236,7 +236,7 @@ def subsonic_rest(blocks, **kwargs):
 
     # Fill state vector in each block
     for block in blocks:
-        block.state.U = Q
+        block.state.U[:, :, :] = Q
         block.state.non_dim()
 
 def explosion_trapezoid(blocks, **kwargs):


### PR DESCRIPTION
Fixed some instances where the whole state would be initialized to a single (1, 1, 4) array, instead of broadcasting the (1, 1, 4) array to the full (ny, nx, 4) state array